### PR TITLE
搜索增强细节优化

### DIFF
--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -384,7 +384,7 @@ jQuery($ => {
                     log("搜索增强 初始化");
 
                     // 2. 修改父级grid布局
-                    $form.parent().parent().css('grid-template-columns', '1fr minmax(100px, auto) minmax(100px, auto) 2fr 2fr 1fr 2fr');
+                    $form.parent().parent().css('grid-template-columns', '1fr minmax(60px, auto) minmax(60px, auto) minmax(60px, auto) 2fr minmax(30px, auto) 2fr 1fr 2fr');
 
                     // 3. 搜索UID，PID和作者
                     ($form => {


### PR DESCRIPTION
修改了顶部导航栏UID、PID、作者和收藏人数下拉框的最小宽度，以便在非最大化及缩小的窗口中，尽可能保证顶栏显示完全，在1080P分辨率显示器上能做到在2/3的宽度下显示所有搜索框且不会过长导致导航栏显示不完整【注意：个人知识有限，没法调整到“搜索作品”搜索栏的最小大小，还请作者或热心网友帮忙调整和完善】