### PR TITLE
fix(pixiv plus): correct search label of tag & adapt to new pixiv frontend site & fix unexpected requests

### DIFF
--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -101,7 +101,7 @@ jQuery($ => {
     const illust = () => {
         // 1. 判断是否已有作品id(兼容按左右方向键翻页的情况)
         const preIllustId = $('body').attr('ahao_illust_id');
-        const paramRegex = location.href.match(/artworks\/(\d*)/);
+        const paramRegex = location.href.match(/artworks\/(\d*)(#\d*)?$/);
         const urlIllustId = !!paramRegex && paramRegex.length > 0 ? paramRegex[1] : '';
         // 2. 如果illust_id没变, 则不更新json
         if (parseInt(preIllustId) === parseInt(urlIllustId)) {

--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -438,6 +438,7 @@ jQuery($ => {
                         const $select = $(`
                     <select id="select-ahao-favorites">
                         <option value=""></option>
+                        <option value="50000users入り">50000users入り</option>
                         <option value="30000users入り">30000users入り</option>
                         <option value="20000users入り">20000users入り</option>
                         <option value="10000users入り">10000users入り</option>
@@ -456,13 +457,9 @@ jQuery($ => {
                             e.preventDefault();
                             if (!!$select.val()) {
                                 // 2.4.1. 去除旧的搜索选项
-                                $input.val((index, val) => val.replace(/\d*users入り/g, ''));
-                                $input.val((index, val) => val.replace(/\d*$/g, ''));
-                                // 2.4.2. 去除多余空格
-                                $input.val((index, val) => val.replace(/\s\s*/g, ''));
-                                $input.val((index, val) => `${val} `);
-                                // 2.4.3. 添加新的搜索选项
-                                $input.val((index, val) => `${val}${$select.val()}`);
+                                $input.val((index, val) => val.split(' ').filter((tag) => !!tag && !/users入り$/.test(tag)).join(' '));
+                                // 2.4.2. 添加新的搜索选项
+                                $input.val((index, val) => `${val} ${$select.val()}`);
                             }
                             const value = encodeURIComponent($input.val());
                             if (!!value) {

--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -377,7 +377,11 @@ jQuery($ => {
                 for (let i = 0, len = mutations.length; i < len; i++) {
                     const mutation = mutations[i];
                     // 1. 判断是否改变节点, 或者是否有[form]节点
-                    const $form = $('#js-mount-point-header form:not([action]), #root div[style="position: static; z-index: auto;"] form:not([action])');
+                    const $form = $('form:not([action])').filter(function () {
+                        if ($(this).find('.charcoal-text-field-root').length > 0) {
+                            return true;
+                        };
+                    });
                     if (mutation.type !== 'childList' || !$form.length) {
                         continue;
                     }

--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -80,29 +80,21 @@ jQuery($ => {
     const debug = true;
     const [log, error] = [debug ? console.log : () => { }, console.error];
 
+    let authorDetails = {};
+    const getAuthorDetails = (authorId) => {
+        if (!authorDetails || String(authorDetails.userId) !== String(authorId)) {
+            $.ajax({
+                url: `/ajax/user/${authorId}`,
+                dataType: 'json',
+                async: false,
+                success: (response) => {
+                    authorDetails = response.body;
+                },
+            });
+        }
+        return authorDetails;
+    }
 
-    let globalData;
-
-    let preloadData;
-    const initData = () => {
-        $.ajax({
-            url: location.href, async: false,
-            success: response => {
-                const html = document.createElement('html');
-                html.innerHTML = response;
-                globalData = JSON.parse($(html).find('meta[name="global-data"]').attr('content') || '{}');
-                preloadData = JSON.parse($(html).find('meta[name="preload-data"]').attr('content') || '{}');
-            }
-        });
-    };
-    const getPreloadData = () => {
-        if (!preloadData) { initData(); }
-        return preloadData;
-    };
-    const getGlobalData = () => {
-        if (!globalData) { initData(); }
-        return globalData;
-    };
     const lang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
     let illustJson = {};
 
@@ -126,12 +118,6 @@ jQuery($ => {
             });
         }
         return illustJson;
-    };
-    const getUid = () => {
-        if (!preloadData || !preloadData.user || !Object.keys(preloadData.user)[0]) {
-            initData();
-        }
-        return preloadData && preloadData.user && Object.keys(preloadData.user)[0];
     };
     const observerFactory = function (option) {
         let options;
@@ -843,7 +829,8 @@ jQuery($ => {
                     $row.before($ahaoRow);
 
                     // 2. 显示画师id, 点击自动复制到剪贴板
-                    const uid = getUid();
+                    const $data = $row.find('[data-gtm-value]');
+                    const uid = $($data[0]).data('gtm-value');
                     const $uid = $(`<li id="uid"><div style="font-size: 20px;font-weight: 700;color: #333;margin-right: 8px;line-height: 1">UID:${uid}</div></li>`)
                         .on('click', function () {
                             const $this = $(this);
@@ -856,7 +843,7 @@ jQuery($ => {
                     $ul.append($uid);
 
                     // 3. 显示画师背景图
-                    const background = preloadData.user[uid].background;
+                    const background = getAuthorDetails(uid).background;
                     const url = (background && background.url) || '';
                     const $bgli = $('<li><div style="font-size: 20px;font-weight: 700;color: #333;margin-right: 8px;line-height: 1"></div></li>');
                     const $bg = $bgli.find('div');
@@ -887,8 +874,9 @@ jQuery($ => {
                     }
 
                     // 2. 显示画师背景图
-                    const uid = getUid();
-                    const background = preloadData.user[uid].background;
+                    const $data = $row.find('[data-gtm-value]');
+                    const uid = $($data[0]).data('gtm-value');
+                    const background = getAuthorDetails(uid).background;
                     const url = (background && background.url) || '';
                     const $bgDiv = $row.clone().attr('id', 'ahao-background');
                     $bgDiv.children('a').remove();

--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -362,12 +362,20 @@ jQuery($ => {
             observerFactory((mutations, observer) => {
                 for (let i = 0, len = mutations.length; i < len; i++) {
                     const mutation = mutations[i];
+
                     // 1. 判断是否改变节点, 或者是否有[form]节点
-                    const $form = $('form:not([action])').filter(function () {
-                        if ($(this).find('.charcoal-text-field-root').length > 0) {
+                    let $form = $("form:not([action])").filter(function () {
+                        if ($(this).find(".charcoal-text-field-root").length > 0) {
                             return true;
-                        };
+                        }
                     });
+                    if (!$form.length) {
+                        // 新版本的 Pixiv 搜索栏表单不存在，查找旧版本的 Pixiv 搜索栏表单
+                        $form = $(
+                            '#js-mount-point-header form:not([action]), #root div[style="position: static; z-index: auto;"] form:not([action])'
+                        );
+                    }
+                          
                     if (mutation.type !== 'childList' || !$form.length) {
                         continue;
                     }

--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -109,7 +109,7 @@ jQuery($ => {
     const illust = () => {
         // 1. 判断是否已有作品id(兼容按左右方向键翻页的情况)
         const preIllustId = $('body').attr('ahao_illust_id');
-        const paramRegex = location.href.match(/artworks\/(\d*)$/);
+        const paramRegex = location.href.match(/artworks\/(\d*)/);
         const urlIllustId = !!paramRegex && paramRegex.length > 0 ? paramRegex[1] : '';
         // 2. 如果illust_id没变, 则不更新json
         if (parseInt(preIllustId) === parseInt(urlIllustId)) {

--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -417,11 +417,12 @@ jQuery($ => {
                                     return;
                                 }
                                 // 2.2. 新窗口打开url
+                                let url;
                                 if (options.searchType == idSearch){
-                                    const url = option.url + val;
+                                    url = option.url + val;
                                 }
                                 if (options.searchType == otherSearch){
-                                    const url = option.url + val + '&s_mode=s_usr';
+                                    url = option.url + val + '&s_mode=s_usr';
                                 }
                                 window.open(url);
                                 // 2.3. 清空input等待下次输入


### PR DESCRIPTION
1. 修复了原始标签以数字结尾时，选择用户收藏标签，原始标签的数字被去除的问题。
    例如对于标签：[`ゼノブレイド3`](https://www.pixiv.net/tags/%E3%82%BC%E3%83%8E%E3%83%96%E3%83%AC%E3%82%A4%E3%83%893/artworks?s_mode=s_tag)，当选择 10000 用户收藏时，新的标签会变为 [`ゼノブレイド 10000users入り`](https://www.pixiv.net/tags/%E3%82%BC%E3%83%8E%E3%83%96%E3%83%AC%E3%82%A4%E3%83%89%2010000users%E5%85%A5%E3%82%8A/artworks?s_mode=s_tag)，而非预期的 `ゼノブレイド3 10000users入り`。

2. 添加了 50000 用户收藏的选项。因为比较常用 XD。

3. 兼容 PIxiv 新主页，通过主页时间线（动态）进入作品页的 URL，也能正确显示原始图像，例如：`https://www.pixiv.net/artworks/127718700#1`.

4. 兼容 Pixiv 新主页的 Header 栏，正确显示搜索框。(#100)

5. 兼容 Pixiv 新主页的 Meta 元数据，正确显示作品页面中画师的背景图和 UID。(#100，#101)

6. 修复循环请求导致风控的问题。(#101) 新的实现里不再请求当前页面的 HTML 文档，而是通过查找画师信息栏 DOM 节点，获取画师的 UID，再调用 `/ajax/user/${uid}` 接口拿到需要的详细信息。