### PR TITLE
Search Enhancement Optimizations

### DIFF
--- a/Pixiv 增强.user.js
+++ b/Pixiv 增强.user.js
@@ -322,15 +322,15 @@ jQuery($ => {
         const isNewVersion = $form.find('div.charcoal-text-field-root').length > 0;
         // 2.2 根据上面的判断来应用哪套布局：真，走适配新版本样式。假，走适配老版本样式
         if (isNewVersion) {
-            $form.parent().parent().css({ 'grid-template-columns': '1fr 1fr 1fr 1fr 1fr 1fr 1fr', 'gap': '10px' });
+            $form.parent().parent().css({ 'grid-template-columns': 'auto auto auto 1fr auto auto', 'gap': '10px', 'width': '100%', 'align-items': 'center'});
         } else {
             $form.parent().parent().css('grid-template-columns', '1fr minmax(0px, 219px) minmax(0px, 219px) minmax(0px, 538px) minmax(0px, 538px) minmax(0px, 219px) 2fr');
         }
-        $form.parent().parent().parent().css('grid-template-columns', '1fr 2fr 1fr');
+        $form.parent().parent().parent().css('grid-template-columns', 'auto 1fr auto');
 
         // 设置官方原生搜索框的最小宽度
         const $formInput = $form.find('input[type="text"]:first');
-        $formInput.css('min-width', '120px');
+        $formInput.css('min-width', '115px');
 
         // 3. 搜索UID，PID和作者
         const initSearch = option => {
@@ -386,8 +386,8 @@ jQuery($ => {
         if(features.searchFavourite.isEnable()) {
             const $input = $form.find('input[type="text"]:first');
             const $select = $(`
-                    <select id="select-ahao-favorites">
-                        <option value=""></option>
+                    <select id="select-ahao-favorites" style="height: 32px; border-radius: 16px; border: 1px solid rgba(0,0,0,0.16); padding: 0 8px; width: 100%; min-width: 120px">
+                        <option value="">筛选收藏</option>
                         <option value="50000users入り">50000users入り</option>
                         <option value="30000users入り">30000users入り</option>
                         <option value="20000users入り">20000users入り</option>


### PR DESCRIPTION
1. 优化搜索增强中，现版本顶栏搜索栏在宽屏窗口下两边仍有较为明显空白处，把部分 1fr 改为 auto 使其能够自适应各种窗口宽度下自动调整铺满顶栏保证美观性

2.  搜索增强”里面，精简并强化功能代码整体性 2. 适度为顶栏搜索中的“4. 搜索条件”筛查收藏数的子功能添加外观效果，这比单纯无任何效果的筛选框要美观一点

优化前效果：
<img width="1903" height="226" alt="image" src="https://github.com/user-attachments/assets/dadbadaa-a7f4-4886-9a9e-93f313a9ab35" />

优化后效果：
<img width="1908" height="241" alt="image" src="https://github.com/user-attachments/assets/5ce08a8a-cdca-4432-8ed2-7a12402e87f0" />
